### PR TITLE
chore: update GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,10 +18,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Java and Maven - setup settings.xml
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: 17
           distribution: 'temurin'

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -9,7 +9,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Get pom informations
         id: pom-info
@@ -36,7 +36,7 @@ jobs:
           package-type: "maven"
 
       - name: Clean old releases - keep last 2
-        uses: dev-drprasad/delete-older-releases@v0.2.0
+        uses: dev-drprasad/delete-older-releases@v0.3.4
         with:
           keep_latest: 2
           delete_tags: true

--- a/.github/workflows/reusable-on-merge.yml
+++ b/.github/workflows/reusable-on-merge.yml
@@ -30,10 +30,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Java and Maven
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: 17
           distribution: 'temurin'

--- a/.github/workflows/tagAndRelease.yml
+++ b/.github/workflows/tagAndRelease.yml
@@ -10,10 +10,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Java and Maven - setup settings.xml
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: 17
           distribution: 'temurin'
@@ -39,12 +39,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Install Java and Maven - setup settings.xml
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: 17
           distribution: 'temurin'
@@ -58,14 +58,14 @@ jobs:
 
       - name: 'Get Previous tag'
         id: previous-tag
-        uses: "WyriHaximus/github-action-get-previous-tag@v1"
+        uses: "WyriHaximus/github-action-get-previous-tag@v2"
 
       - name: Display tag
         id: display-tag
         run: |
           echo "tag: ${{ steps.previous-tag.outputs.tag }}"
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ steps.previous-tag.outputs.tag }}
 


### PR DESCRIPTION
## Summary
- `actions/checkout`: v4 → v6
- `actions/setup-java`: v4 → v5
- `dev-drprasad/delete-older-releases`: v0.2.0 → v0.3.4
- `WyriHaximus/github-action-get-previous-tag`: v1 → v2

🤖 Generated with [Claude Code](https://claude.ai/claude-code)